### PR TITLE
Missing Easy quests

### DIFF
--- a/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.1-Journey-Up-the-Anduin.o8d
+++ b/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.1-Journey-Up-the-Anduin.o8d
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a21af4e8-be4b-4cda-a6b6-534f9717391f" sleeveid="0">
+  <section name="Quest" shared="True">
+    <card qty="1" id="b4b0bdc8-5edb-40c9-a9ca-dac60fe7cb38">Traveling North</card>
+    <card qty="1" id="b77a9e58-9a88-4aec-9029-8d84269b0a3c">Woodmen Under Attack</card>
+    <card qty="1" id="2d1d915f-f889-4100-81b7-910ce93edff7">The Passage of the Ford</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="2" id="93008a44-68db-40ea-8b41-81cf5bb2bae8">Wooded Riverbank</card>
+    <card qty="1" id="1a06164a-8f54-49b7-a067-52680893f69d">Frenzied Creature</card>
+    <card qty="3" id="ce14480c-dfc0-4b30-8f8d-e878e003f4cd">Dangerous Crossing</card>
+    <card qty="1" id="ec9f4d54-a419-4b3e-a6b9-605119950d07">Goblin Troop</card>
+    <card qty="2" id="552b11aa-b91e-44aa-8e54-1bad1aa74bbd">Stray Goblin</card>
+    <card qty="1" id="8615beb7-a9f7-4852-bc0a-3d1a5f2c9532">Pack of Wargs</card>
+    <card qty="1" id="db960347-11ee-4ad7-8784-e4827fb7daaf">Hills of Wilderland</card>
+    <card qty="2" id="74fc62c2-b1b6-4338-819a-1f00f871312c">Lonely Lands</card>
+    <card qty="1" id="daa67624-18ba-43a3-92c6-6e5586166bb0">Ruined Supplies</card>
+    <card qty="1" id="b81e837e-f4e8-43e9-892a-8bfaecbd1416">Lost in the Wild</card>
+    <card qty="1" id="0f2929de-bef9-40b8-b0ed-de69e136188f">Weighed Down</card>
+    <card qty="3" id="51223bd0-ffd1-11df-a976-0801200c9111">Misty Mountain Goblins</card>
+    <card qty="2" id="51223bd0-ffd1-11df-a976-0801200c9113">Banks of the Anduin</card>
+    <card qty="1" id="51223bd0-ffd1-11df-a976-0801200c9114">Gladden Fields</card>
+  </section>
+  <section name="Special" shared="True">
+    <card qty="1" id="51223bd0-ffd1-11df-a976-0801200c9081">Wolf Rider</card>
+    <card qty="1" id="51223bd0-ffd1-11df-a976-0801200c9082">Hill Troll</card>
+    <card qty="2" id="51223bd0-ffd1-11df-a976-0801200c9083">Goblin Sniper</card>
+    <card qty="2" id="51223bd0-ffd1-11df-a976-0801200c9085">Wargs</card>
+  </section>
+  <section name="Setup" shared="True">
+    <card qty="1" id="1d4d59f4-def5-4c9e-ba3f-8a28e7f66c73">Woodman Village</card>
+    <card qty="1" id="56634de4-2ef2-4739-b549-fa591e7032eb">The Old Ford</card>
+  </section>
+  <section name="Hero" shared="False" />
+  <section name="Ally" shared="False" />
+  <section name="Attachment" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Side Quest" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Second Quest Deck" shared="True" />
+  <section name="Second Special" shared="True" />
+  <section name="Staging Setup" shared="True" />
+  <section name="Active Setup" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.2-Lost-in-Mirkwood.o8d
+++ b/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.2-Lost-in-Mirkwood.o8d
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a21af4e8-be4b-4cda-a6b6-534f9717391f" sleeveid="0">
+  <section name="Quest" shared="True">
+    <card qty="1" id="504d7fe3-a3a1-4e2c-b59d-dd391d370a20">Ambushed at Night</card>
+    <card qty="1" id="48c82a72-ad2f-4452-9906-b5505caf27e1">Spiders of Mirkwood</card>
+    <card qty="1" id="65ef76b1-e624-4763-8906-899e4630225f">Dol Guldur Orcs</card>
+    <card qty="1" id="4ee0293f-5c0c-4f7a-bc10-680d84eb9214">Carried Away</card>
+    <card qty="1" id="ac9fe707-143f-492e-89e3-bdd02973a0f2">Truly Lost</card>
+    <card qty="1" id="e3fed535-98f8-461d-a092-7ada49be2550">The Forest of Great Fear</card>
+    <card qty="1" id="d4686e4d-2d50-4ffd-9b95-7bcdf9b2a494">Escape from Taur-nu-Fuin</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="1" id="25cf58f2-9d92-4971-8817-a7e335d9ac5d">Overgrown Path</card>
+    <card qty="1" id="ff79510f-a6c3-4357-a582-853e5bb3e2bc">Abadoned Village</card>
+    <card qty="1" id="0f3c746e-2d23-4cb9-a481-f919ffc8cdee">Bare Hilltop</card>
+    <card qty="1" id="626abd2c-11bc-416b-9db6-a72d5525d3de">Forest Clearing</card>
+    <card qty="2" id="a4e9aa38-54a7-4e99-bab6-330804b24a6e">Twilight Hall</card>
+    <card qty="1" id="8165f1ef-d9df-464e-bd56-5baf4e43325f">Mirkwood Patrol</card>
+    <card qty="1" id="efdbe76c-5b41-4f28-a390-a72ec784e5a3">Ravenous Spider</card>
+    <card qty="1" id="5f1ef9c5-ccb2-4f1e-bc5b-9a1de708d2ba">Unseen Danger</card>
+    <card qty="3" id="388d173e-e32a-4e02-b029-99180e34b014">Vastness of Mirkwood</card>
+    <card qty="1" id="fcb54294-8a36-4a51-bf1b-7d75ac1598e2">Accursed Forest</card>
+    <card qty="2" id="408752c0-cee3-41ba-86c2-d01085546cef">Dark Black Woods</card>
+    <card qty="1" id="fc70a2bc-c2ba-4364-a609-811daa0d6780">Gathering Gloom</card>
+    <card qty="2" id="9b5e1acd-c396-464d-ab54-df86833aad07">Swarm of Bats</card>
+    <card qty="1" id="51223bd0-ffd1-11df-a976-0801200c9097">East Bight Patrol</card>
+    <card qty="1" id="51223bd0-ffd1-11df-a976-0801200c9098">Black Forest Bats</card>
+    <card qty="2" id="51223bd0-ffd1-11df-a976-0801200c9099">Old Forest Road</card>
+    <card qty="2" id="51223bd0-ffd1-11df-a976-0801200c9100">Forest Gate</card>
+  </section>
+  <section name="Special" shared="True">
+    <card qty="2" id="51223bd0-ffd1-11df-a976-0801200c9074">King Spider</card>
+    <card qty="1" id="51223bd0-ffd1-11df-a976-0801200c9076">Ungoliant's Spawn</card>
+    <card qty="2" id="51223bd0-ffd1-11df-a976-0801200c9077">Great Forest Web</card>
+    <card qty="3" id="51223bd0-ffd1-11df-a976-0801200c9078">Mountains of Mirkwood</card>
+  </section>
+  <section name="Second Special" shared="True">
+    <card qty="3" id="51223bd0-ffd1-11df-a976-0801200c9089">Dol Guldur Orcs</card>
+    <card qty="1" id="51223bd0-ffd1-11df-a976-0801200c9091">Dol Guldur Beastmaster</card>
+    <card qty="1" id="51223bd0-ffd1-11df-a976-0801200c9092">Driven by Shadow</card>
+    <card qty="1" id="51223bd0-ffd1-11df-a976-0801200c9093">The Necromancer's Reach</card>
+    <card qty="1" id="51223bd0-ffd1-11df-a976-0801200c9094">Necromancer's Pass</card>
+    <card qty="2" id="51223bd0-ffd1-11df-a976-0801200c9095">Enchanted Stream</card>
+  </section>
+  <section name="Staging Setup" shared="True">
+    <card qty="1" id="e428dad0-f116-40c3-82fd-6c78bfcdcb32">Searching for a Way Out</card>
+    <card qty="4" id="51223bd0-ffd1-11df-a976-0801200c9096">Forest Spider</card>
+  </section>
+  <section name="Hero" shared="False" />
+  <section name="Ally" shared="False" />
+  <section name="Attachment" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Side Quest" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Second Quest Deck" shared="True" />
+  <section name="Setup" shared="True">
+    <card qty="1" id="1d4d59f4-def5-4c9e-ba3f-8a28e7f66c73">Woodman Village</card>
+  </section>
+  <section name="Active Setup" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.3-The-King's-Quest.o8d
+++ b/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.3-The-King's-Quest.o8d
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a21af4e8-be4b-4cda-a6b6-534f9717391f" sleeveid="0">
+  <section name="Quest" shared="True">
+    <card qty="1" id="e3e98df7-720f-49b8-995a-370961706cec">The Iron Hills</card>
+    <card qty="1" id="e38f5043-50b5-4b2a-a23f-f786106c4055">The Lower Depths</card>
+    <card qty="1" id="bfae3bf9-24e1-46af-b202-fb6c676a5dd9">The Fire Worm</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="1" id="2d4b1381-467e-4bb4-9265-d26dec6125ea">Iron Hills Mine</card>
+    <card qty="3" id="8a7a0942-0bd2-44b1-9a9b-057f38b225e9">Contested Depths</card>
+    <card qty="1" id="e4432b9b-4969-44be-937f-ca2728d57ad4">Deep Chasm</card>
+    <card qty="1" id="4daa4ff5-625a-4949-aef5-fb1349e249fd">Denizen of the Deep</card>
+    <card qty="1" id="23fb0422-0e54-4064-bb76-e5bf3c214709">Stone-troll</card>
+    <card qty="1" id="b7431f72-5157-4a6d-a6c0-86bcf88f2669">Hobgoblin</card>
+    <card qty="1" id="5bcec205-7f6b-44b9-bb4d-9addde372316">Werewolf</card>
+    <card qty="3" id="9b3c0e2a-c874-41b7-9ccd-2798a4884b34">Giant Spider</card>
+    <card qty="2" id="f5d539b2-0b65-493d-8493-5122a0761eed">Black Bats</card>
+    <card qty="3" id="14f41245-2616-4358-a8bb-6b9bcf83cf56">Dark Tunnel</card>
+    <card qty="2" id="1062dfa2-d821-474d-9a8f-9eda79753222">Forked Passage</card>
+    <card qty="3" id="f945cfde-271f-4e93-8eed-93eaaf0fb408">Dark Places</card>
+    <card qty="2" id="cfddac0a-3055-46bd-af9a-8bdda8c9abb6">Eyes in the Dark</card>
+    <card qty="1" id="3566b6df-a1cd-4417-b202-27e0ecc0a966">Afraid of the Dark</card>
+  </section>
+  <section name="Setup" shared="True">
+    <card qty="1" id="42a5a608-0699-4cd5-b69d-f7c3413cd5cd">Fire Drake</card>
+    <card qty="1" id="744e45f8-a808-4d9f-96f4-59e26cff5874">Dragon Hoard</card>
+    <card qty="1" id="6220ef6b-f314-4cf9-92df-f9551d6cfde0">Dragon Breath</card>
+    <card qty="1" id="51b186ac-ddf5-4909-a484-20d273be27c9">Dragon Scales</card>
+  </section>
+  <section name="Hero" shared="False" />
+  <section name="Ally" shared="False" />
+  <section name="Attachment" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Side Quest" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Second Quest Deck" shared="True" />
+  <section name="Special" shared="True">
+    <card qty="1" id="acbf7fd1-9f93-4d0b-b18a-8f0854e028f5">Lightless Grotto</card>
+    <card qty="1" id="9a5884f4-c2a8-4696-97b5-f0c5c5e92b6d">Crumbling Cavern</card>
+    <card qty="1" id="8be23a53-ba85-4db3-8d1f-821da0323cbf">Underground Lake</card>
+    <card qty="1" id="286a5206-9ebb-4ec4-a349-2960ccb2f669">Lost Armory</card>
+    <card qty="1" id="9e490f6c-3873-4cd7-8c80-98a6640b9043">Frightful Den</card>
+    <card qty="1" id="c0c522b2-5f5c-45a0-b6fc-e05c8bb835d8">Ancient Treasury</card>
+  </section>
+  <section name="Second Special" shared="True" />
+  <section name="Staging Setup" shared="True" />
+  <section name="Active Setup" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.4-The-Withered-Heath.o8d
+++ b/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.4-The-Withered-Heath.o8d
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a21af4e8-be4b-4cda-a6b6-534f9717391f" sleeveid="0">
+  <section name="Hero" shared="False" />
+  <section name="Ally" shared="False" />
+  <section name="Attachment" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Side Quest" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Quest" shared="True">
+    <card qty="1" id="21786f6e-9f9c-4850-9277-9ee77b6e0912">Searching for Dragon Sign</card>
+    <card qty="1" id="60ba0781-d051-46f0-97b1-e02fb637b94e">The Cold-Drake Attacks!</card>
+    <card qty="1" id="e70fa96c-f4c7-4d6c-ab14-41831a6eb8c8">Hunting the Beast</card>
+    <card qty="1" id="9656a1c9-dd90-4096-b2ba-eb2491d08403">A Cornered Dragon</card>
+  </section>
+  <section name="Second Quest Deck" shared="True" />
+  <section name="Encounter" shared="True">
+    <card qty="1" id="ebde9bba-fd89-4098-ad60-9d1d4e746d23">Snow-troll</card>
+    <card qty="2" id="beedf6c6-6214-47d8-bd82-81280543b141">Dragon Hatchling</card>
+    <card qty="3" id="351afed2-188b-42d4-9b3a-bccb510ae7d2">Mountain Pass</card>
+    <card qty="3" id="ef4ae3ca-ce48-4cad-88ee-23917e9dcdcc">Dwarven Door</card>
+    <card qty="2" id="15ebc613-43fc-4c9b-ac71-91840d853e60">Cave Entrance</card>
+    <card qty="2" id="80764232-a3c9-47f1-9034-9c9ac82002e4">Creature Den</card>
+    <card qty="1" id="2b158c89-59d6-40a2-af56-6db21dc62e73">High Falls</card>
+    <card qty="1" id="572ba251-0abb-4a81-b38b-d695123b7219">Heavy Snow</card>
+    <card qty="2" id="cb64fac2-c5ea-4233-86ed-90e30181a520">Deadly Cold</card>
+    <card qty="1" id="daa67624-18ba-43a3-92c6-6e5586166bb0">Ruined Supplies</card>
+    <card qty="1" id="b81e837e-f4e8-43e9-892a-8bfaecbd1416">Lost in the Wild</card>
+    <card qty="1" id="0f2929de-bef9-40b8-b0ed-de69e136188f">Weighed Down</card>
+    <card qty="1" id="5bcec205-7f6b-44b9-bb4d-9addde372316">Werewolf</card>
+    <card qty="3" id="9b3c0e2a-c874-41b7-9ccd-2798a4884b34">Giant Spider</card>
+    <card qty="2" id="f5d539b2-0b65-493d-8493-5122a0761eed">Black Bats</card>
+  </section>
+  <section name="Special" shared="True">
+    <card qty="1" id="c0c522b2-5f5c-45a0-b6fc-e05c8bb835d8">Ancient Treasury</card>
+    <card qty="1" id="286a5206-9ebb-4ec4-a349-2960ccb2f669">Lost Armory</card>
+    <card qty="1" id="9e490f6c-3873-4cd7-8c80-98a6640b9043">Frightful Den</card>
+    <card qty="1" id="acbf7fd1-9f93-4d0b-b18a-8f0854e028f5">Lightless Grotto</card>
+    <card qty="1" id="9a5884f4-c2a8-4696-97b5-f0c5c5e92b6d">Crumbling Cavern</card>
+    <card qty="1" id="8be23a53-ba85-4db3-8d1f-821da0323cbf">Underground Lake</card>
+  </section>
+  <section name="Second Special" shared="True" />
+  <section name="Setup" shared="True">
+    <card qty="1" id="e9217231-de12-48ef-9351-f7d992643c2f">Cold-Drake</card>
+    <card qty="4" id="b922eedf-eea0-471d-bc52-90becc2a0769">Dragon Sign</card>
+  </section>
+  <section name="Staging Setup" shared="True" />
+  <section name="Active Setup" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.5-Roam-Across-Rhovanion.o8d
+++ b/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.5-Roam-Across-Rhovanion.o8d
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a21af4e8-be4b-4cda-a6b6-534f9717391f" sleeveid="0">
+  <section name="Hero" shared="False" />
+  <section name="Ally" shared="False" />
+  <section name="Attachment" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Side Quest" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Quest" shared="True">
+    <card qty="1" id="4d85eda6-14e2-4dee-b912-31056fc6a2cc">The Goblin’s Task</card>
+    <card qty="1" id="8cb63364-11e8-4044-9712-613ccbfcfa5f">Rescue Tiny</card>
+    <card qty="1" id="7ab4b2ae-a646-4e24-bec6-7cd85d8a1c7c">Retrieve Urdug’s Horn</card>
+    <card qty="1" id="a4cd5ce9-fc29-44b6-9bee-eafbbd431c49">Find Durin’s Key</card>
+    <card qty="1" id="f63c9a8e-23dc-4c3a-bbff-00bd585e27bc">Urdug’s Gambit</card>
+  </section>
+  <section name="Second Quest Deck" shared="True" />
+  <section name="Encounter" shared="True">
+    <card qty="1" id="caaafdd2-3559-496a-a08c-ce81ec212b6c">Grey Mountain Giant</card>
+    <card qty="2" id="4c653b80-0b0e-4383-b0bb-aa31f12b3e74">Hunting Eagle</card>
+    <card qty="2" id="eed0925e-5376-4ad0-b571-69cfbb2118ae">Wilderland Bear</card>
+    <card qty="1" id="702e659f-949c-491d-84ab-e1d5b4166f46">Grey Moorland</card>
+    <card qty="2" id="68e3c34a-1af7-410f-ad57-85386181c6d7">Deep Ravine</card>
+    <card qty="3" id="3733b627-08bd-4d12-a2ec-dadfcbfc6695">Slopes of Ered Mithrin</card>
+    <card qty="1" id="b1612370-142d-4557-8884-b3da12b4baca">Sneaking Off</card>
+    <card qty="3" id="5edbdc1f-e177-4a8b-b4f1-8475fe297a4b">Harsh Weather</card>
+    <card qty="2" id="edfb7ef3-dee9-4cf4-986e-5698bb3fb320">Wild Creatures</card>
+    <card qty="1" id="8615beb7-a9f7-4852-bc0a-3d1a5f2c9532">Pack of Wargs</card>
+    <card qty="1" id="db960347-11ee-4ad7-8784-e4827fb7daaf">Hills of Wilderland</card>
+    <card qty="2" id="74fc62c2-b1b6-4338-819a-1f00f871312c">Lonely Lands</card>
+    <card qty="1" id="daa67624-18ba-43a3-92c6-6e5586166bb0">Ruined Supplies</card>
+    <card qty="1" id="b81e837e-f4e8-43e9-892a-8bfaecbd1416">Lost in the Wild</card>
+    <card qty="1" id="0f2929de-bef9-40b8-b0ed-de69e136188f">Weighed Down</card>
+    <card qty="1" id="23fb0422-0e54-4064-bb76-e5bf3c214709">Stone-troll</card>
+    <card qty="1" id="b7431f72-5157-4a6d-a6c0-86bcf88f2669">Hobgoblin</card>
+  </section>
+  <section name="Special" shared="True" />
+  <section name="Second Special" shared="True" />
+  <section name="Setup" shared="True">
+    <card qty="1" id="0e90a1fb-b498-4b6e-a6c8-de3e3ed38aa4">Urdug</card>
+    <card qty="1" id="0909409e-d2d3-4304-b239-76bb6da0dceb">Durin’s Key</card>
+    <card qty="1" id="9e864a49-89b3-4ea0-be1f-f4336adfa088">Urdug’s Horn</card>
+    <card qty="1" id="f8716c9e-b35a-474d-8800-cc0256f38b36">Tiny</card>
+  </section>
+  <section name="Staging Setup" shared="True" />
+  <section name="Active Setup" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.6-Fire-in-the-Night.o8d
+++ b/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.6-Fire-in-the-Night.o8d
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a21af4e8-be4b-4cda-a6b6-534f9717391f" sleeveid="0">
+  <section name="Hero" shared="False" />
+  <section name="Ally" shared="False" />
+  <section name="Attachment" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Side Quest" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Quest" shared="True">
+    <card qty="1" id="1ab32b8c-b942-4c77-af19-9703fba1dfa9">Hrogar’s Hill</card>
+  </section>
+  <section name="Second Quest Deck" shared="True" />
+  <section name="Encounter" shared="True">
+    <card qty="1" id="a917100d-1b9b-4335-a55f-75291e0cab6e">The Dragon’s Thrall</card>
+    <card qty="4" id="3e0619e9-ffd1-4c1b-8b65-f603202cde4f">Orc of the Flame</card>
+    <card qty="1" id="aba5ebdb-81d8-4e41-bddd-568f9ab2bd13">Town Gate</card>
+    <card qty="3" id="3b7c4f67-7de4-4b77-be50-0fd86e4ef2bc">Wooden Palisade</card>
+    <card qty="1" id="f57aeb37-4f19-4e5f-ae34-326c3b8b62f2">Burning Watchtower</card>
+    <card qty="2" id="721bbc14-f14c-4464-9963-55a77ab2d9bc">Powerful in Wrath</card>
+    <card qty="1" id="bcd41784-d260-4165-ae0f-74cb844d10b3">The Dragon’s Fury</card>
+    <card qty="1" id="463d0c53-2275-410f-b311-139f19561b46">Bright Flames</card>
+    <card qty="1" id="fcb54294-8a36-4a51-bf1b-7d75ac1598e2">Accursed Forest</card>
+    <card qty="2" id="408752c0-cee3-41ba-86c2-d01085546cef">Dark Black Woods</card>
+    <card qty="1" id="fc70a2bc-c2ba-4364-a609-811daa0d6780">Gathering Gloom</card>
+    <card qty="2" id="9b5e1acd-c396-464d-ab54-df86833aad07">Swarm of Bats</card>
+    <card qty="1" id="ec9f4d54-a419-4b3e-a6b9-605119950d07">Goblin Troop</card>
+    <card qty="2" id="552b11aa-b91e-44aa-8e54-1bad1aa74bbd">Stray Goblin</card>
+  </section>
+  <section name="Special" shared="True">
+    <card qty="1" id="dae6e913-3b2e-4e53-aad4-69946d3386ca">Draw Her Fire</card>
+    <card qty="1" id="a6b39458-b0f1-4b5d-a915-d3921eb35658">Fortify the Defense</card>
+    <card qty="1" id="73515869-890b-4169-9104-b2e882d921ae">Rally the Woodmen</card>
+    <card qty="1" id="5fefdbc7-05e2-4c1b-96fd-46121f87d6b3">Douse the Flames</card>
+    <card qty="1" id="a6e68650-e413-4e85-b687-b927d5a87821">Hold the Door</card>
+    <card qty="1" id="a837fe8b-6f21-4d20-9897-89a3c4706b40">Defend the Town</card>
+    <card qty="1" id="df9ba79f-91a3-4fc7-a2af-6bddcc795f29">Rout the Goblins</card>
+    <card qty="1" id="1574141b-b11e-4be9-82c9-ddc1fb2f5269">Face the Dragon</card>
+  </section>
+  <section name="Second Special" shared="True" />
+  <section name="Setup" shared="True" />
+  <section name="Staging Setup" shared="True">
+    <card qty="1" id="f7badc7a-4e37-4606-8557-0fa4719227c0">Dagnir</card>
+  </section>
+  <section name="Active Setup" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.7-The-Ghost-of-Framsburg.o8d
+++ b/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.7-The-Ghost-of-Framsburg.o8d
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a21af4e8-be4b-4cda-a6b6-534f9717391f" sleeveid="0">
+  <section name="Quest" shared="True">
+    <card qty="1" id="9b75cef3-e5a3-4284-aff6-9a0b473fa37d">The Haunted Keep</card>
+    <card qty="1" id="48d2ea1f-449b-4af9-9f43-c70fffd66991">Searching the Ruins</card>
+    <card qty="1" id="6948a0fa-e13f-4023-865f-3c8b6599c6a0">The Cursed Shade</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="1" id="c3aff9c9-640f-4e90-85f3-6e245c2156fe">Crypt Key</card>
+    <card qty="1" id="29662c71-2f27-405c-ae5a-db519ed91f33">Old Lantern</card>
+    <card qty="1" id="5dbc4cec-84c9-420b-809f-088296eb4a62">Scatha’s Teeth</card>
+    <card qty="1" id="f829839e-b79d-465a-8ca9-bf6af975ce7b">Fram’s Shade</card>
+    <card qty="2" id="36ac198d-0248-464a-8919-36f96b8e7caf">Crypt Stalker</card>
+    <card qty="2" id="62d814e4-e0cf-437b-8ee7-b26478beb721">Evil Spectre</card>
+    <card qty="1" id="11c67697-29da-4c76-bf89-985c2c036940">Forgotten Crypt</card>
+    <card qty="1" id="4bae8841-e3e4-4a93-b10f-8544eaab9cb3">Hidden Staircase</card>
+    <card qty="1" id="ed7b5f3e-432b-4dd7-85f9-6dea5ff62d3d">Moonlit Passage</card>
+    <card qty="1" id="f2c22e9a-c3f6-450c-b891-98e0e5c18b6c">Cursed Tower</card>
+    <card qty="1" id="bececd5f-87dd-4141-8ecf-69e43ecc0ff4">Abandoned Ruins</card>
+    <card qty="3" id="f5a65abc-e3df-4d26-aeed-2a3b1effb005">Slammed Shut</card>
+    <card qty="1" id="3566b6df-a1cd-4417-b202-27e0ecc0a966">Afraid of the Dark</card>
+    <card qty="2" id="cfddac0a-3055-46bd-af9a-8bdda8c9abb6">Eyes in the Dark</card>
+    <card qty="1" id="5bcec205-7f6b-44b9-bb4d-9addde372316">Werewolf</card>
+    <card qty="3" id="9b3c0e2a-c874-41b7-9ccd-2798a4884b34">Giant Spider</card>
+    <card qty="2" id="f5d539b2-0b65-493d-8493-5122a0761eed">Black Bats</card>
+  </section>
+  <section name="Setup" shared="True">
+    <card qty="1" id="315c85eb-9c20-46a1-b445-e5197cd15032">The Cursed Tomb</card>
+  </section>
+  <section name="Staging Setup" shared="True">
+    <card qty="1" id="4bae8841-e3e4-4a93-b10f-8544eaab9cb3">Hidden Staircase</card>
+    <card qty="1" id="f2c22e9a-c3f6-450c-b891-98e0e5c18b6c">Cursed Tower</card>
+    <card qty="1" id="ed7b5f3e-432b-4dd7-85f9-6dea5ff62d3d">Moonlit Passage</card>
+    <card qty="1" id="8c4cc797-13e6-4ee4-a991-7ec76866418a">Haunted Hall</card>
+    <card qty="1" id="11c67697-29da-4c76-bf89-985c2c036940">Forgotten Crypt</card>
+  </section>
+  <section name="Hero" shared="False" />
+  <section name="Ally" shared="False" />
+  <section name="Attachment" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Side Quest" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Second Quest Deck" shared="True" />
+  <section name="Special" shared="True" />
+  <section name="Second Special" shared="True" />
+  <section name="Active Setup" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.8-Mount-Gundabad.o8d
+++ b/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.8-Mount-Gundabad.o8d
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a21af4e8-be4b-4cda-a6b6-534f9717391f" sleeveid="0">
+  <section name="Quest" shared="True">
+    <card qty="1" id="8eae3ce5-c37e-4092-b91d-02c0721ffc0d">The Side Door</card>
+    <card qty="1" id="044a7b39-8ef6-41c7-bb99-ce209f700b09">Exploring Gundabad</card>
+    <card qty="1" id="5a0d35ad-e9af-48b1-8454-534753394ed2">Exploring Gundabad</card>
+    <card qty="1" id="cf435143-655b-4a7c-ac6b-f9f61b4cba72">Exploring Gundabad</card>
+    <card qty="1" id="b3147b4e-2a60-402f-a1aa-5d56c002326d">Exploring Gundabad</card>
+    <card qty="1" id="89cd149f-69d3-4d75-887d-96b45730792a">Exploring Gundabad</card>
+    <card qty="1" id="5abd3a4b-2769-401d-aa3c-c904da21b97a">Exploring Gundabad</card>
+    <card qty="1" id="47aada3f-9ee6-455d-8c2d-786962633f34">Exploring Gundabad</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="3" id="3cbe2fe1-e7ab-4213-85dd-fd9b6244479f">Guardian of Gundabad</card>
+    <card qty="2" id="475d31c0-45d5-4a9f-aaac-c23b93c73f03">Dagnir’s Slave</card>
+    <card qty="1" id="d3bd47e5-cf59-4097-9cec-92a15fe56bf4">Deep-dweller</card>
+    <card qty="2" id="a802fd4f-0a1b-440e-8648-ff44601bda2c">Mines of Gundabad</card>
+    <card qty="1" id="f77ffb66-297c-49e0-8ed5-9cc3bd715926">Narrow Stair</card>
+    <card qty="2" id="34c61d95-cb2e-49c4-b85e-5d3c32b02342">Desecrated Ruins</card>
+    <card qty="2" id="fd06cd6e-5741-4bd2-b50c-52052f973208">Suffocating Shadows</card>
+    <card qty="1" id="3566b6df-a1cd-4417-b202-27e0ecc0a966">Afraid of the Dark</card>
+    <card qty="2" id="cfddac0a-3055-46bd-af9a-8bdda8c9abb6">Eyes in the Dark</card>
+    <card qty="1" id="23fb0422-0e54-4064-bb76-e5bf3c214709">Stone-troll</card>
+    <card qty="1" id="b7431f72-5157-4a6d-a6c0-86bcf88f2669">Hobgoblin</card>
+    <card qty="1" id="6220ef6b-f314-4cf9-92df-f9551d6cfde0">Dragon Breath</card>
+    <card qty="1" id="51b186ac-ddf5-4909-a484-20d273be27c9">Dragon Scales</card>
+    <card qty="2" id="1062dfa2-d821-474d-9a8f-9eda79753222">Forked Passage</card>
+    <card qty="3" id="14f41245-2616-4358-a8bb-6b9bcf83cf56">Dark Tunnel</card>
+    <card qty="3" id="f945cfde-271f-4e93-8eed-93eaaf0fb408">Dark Places</card>
+  </section>
+  <section name="Special" shared="True">
+    <card qty="1" id="ea5faa85-5a47-4ab3-a623-3f88df71f7fd">Throat of the Mountain</card>
+    <card qty="1" id="286a5206-9ebb-4ec4-a349-2960ccb2f669">Lost Armory</card>
+    <card qty="1" id="c0c522b2-5f5c-45a0-b6fc-e05c8bb835d8">Ancient Treasury</card>
+    <card qty="1" id="9e490f6c-3873-4cd7-8c80-98a6640b9043">Frightful Den</card>
+    <card qty="1" id="acbf7fd1-9f93-4d0b-b18a-8f0854e028f5">Lightless Grotto</card>
+    <card qty="1" id="9a5884f4-c2a8-4696-97b5-f0c5c5e92b6d">Crumbling Cavern</card>
+    <card qty="1" id="8be23a53-ba85-4db3-8d1f-821da0323cbf">Underground Lake</card>
+    <card qty="1" id="9d1daee2-2d6e-4d9a-87e4-b706779555d4">Dagnir’s Hoard</card>
+  </section>
+  <section name="Setup" shared="True">
+    <card qty="1" id="71060c15-34c0-44ad-885b-4b6c18d2962a">The First Forge</card>
+  </section>
+  <section name="Staging Setup" shared="True">
+    <card qty="1" id="fe2c30ae-dd35-48de-a2c2-4886a0c0783e">Dagnir</card>
+    <card qty="1" id="cfe00736-4ac0-4f51-b698-705b04eca9a4">Wormsbane</card>
+  </section>
+  <section name="Hero" shared="False" />
+  <section name="Ally" shared="False" />
+  <section name="Attachment" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Side Quest" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Second Quest Deck" shared="True" />
+  <section name="Second Special" shared="True" />
+  <section name="Active Setup" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.9-The-Fate-of-Wilderland.o8d
+++ b/o8g/Decks/Quests/Q08-The-Wilds-of-Rhovanion-Ered-Mithrin/Easy/E08.9-The-Fate-of-Wilderland.o8d
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a21af4e8-be4b-4cda-a6b6-534f9717391f" sleeveid="0">
+  <section name="Encounter" shared="True">
+    <card qty="1" id="ec9f4d54-a419-4b3e-a6b9-605119950d07">Goblin Troop</card>
+    <card qty="2" id="552b11aa-b91e-44aa-8e54-1bad1aa74bbd">Stray Goblin</card>
+    <card qty="1" id="8615beb7-a9f7-4852-bc0a-3d1a5f2c9532">Pack of Wargs</card>
+    <card qty="1" id="db960347-11ee-4ad7-8784-e4827fb7daaf">Hills of Wilderland</card>
+    <card qty="2" id="74fc62c2-b1b6-4338-819a-1f00f871312c">Lonely Lands</card>
+    <card qty="1" id="fc70a2bc-c2ba-4364-a609-811daa0d6780">Gathering Gloom</card>
+    <card qty="2" id="9b5e1acd-c396-464d-ab54-df86833aad07">Swarm of Bats</card>
+    <card qty="2" id="3b26d048-24cb-4978-86f9-d255048426d8">Urdug’s Elite</card>
+    <card qty="2" id="3f8273a2-f64c-407c-97fb-4a4ef0bddb0b">Fierce Vanguard</card>
+    <card qty="2" id="4abe9f52-1e56-479a-a59f-c3f7075ec493">Warg-rider</card>
+    <card qty="1" id="98461b3e-54c4-4eb9-9172-616c9bebb0f6">Gate of Gundabad</card>
+    <card qty="3" id="f7117e07-e8d2-4e7d-a5c3-5dd0f1c0d455">Hilltop Battlements</card>
+    <card qty="3" id="7d71aa09-badb-4ba8-9d08-597a8d814020">Dwarven Watchtower</card>
+    <card qty="1" id="882952c5-c3a7-43aa-91d2-8a130b300d5f">Slopes of Gundabad</card>
+    <card qty="2" id="c2d8cd64-a1dc-4bf2-9e61-0336170e73af">Fierce Attack</card>
+    <card qty="2" id="5775b97c-4047-4dc2-b148-b852bad4f9bb">Urdug’s Command</card>
+    <card qty="2" id="c5e9ef20-a88f-40fb-861f-c44de8e12bd9">Dark Clouds</card>
+  </section>
+  <section name="Hero" shared="False" />
+  <section name="Ally" shared="False" />
+  <section name="Attachment" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Side Quest" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Quest" shared="True">
+    <card qty="1" id="99ab7a92-0e3e-4ec2-9a40-0f467920879d">Urdug’s Assault</card>
+    <card qty="1" id="d90a8977-78e1-445d-b57d-a13e0e98f450">Outflanked</card>
+    <card qty="1" id="0fffdddc-d9f9-498a-9669-e840304ebb9b">The Final Push</card>
+  </section>
+  <section name="Second Quest Deck" shared="True" />
+  <section name="Special" shared="True" />
+  <section name="Second Special" shared="True" />
+  <section name="Setup" shared="True" />
+  <section name="Staging Setup" shared="True">
+    <card qty="1" id="7f9cf578-980e-43af-995f-27a84fd54a01">The Heroes’ Defense</card>
+    <card qty="1" id="aeb2f711-4597-42c1-af8c-eb7d6f4fa79a">The Goblins’ Assault</card>
+    <card qty="1" id="315ed83a-1dae-421f-b5ba-1bcb5cd6c2a7">Urdug</card>
+  </section>
+  <section name="Active Setup" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/Quests/Q09-Shadow-in-the-East-Vengeance-of-Mordor/Q09.7-Under-the-Ash-Mountains.o8d
+++ b/o8g/Decks/Quests/Q09-Shadow-in-the-East-Vengeance-of-Mordor/Q09.7-Under-the-Ash-Mountains.o8d
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a21af4e8-be4b-4cda-a6b6-534f9717391f">
+  <section name="Hero" shared="False" />
+  <section name="Ally" shared="False" />
+  <section name="Attachment" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Side Quest" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Quest" shared="True">
+    <card qty="1" id="db69ea89-f018-4534-9661-7c748298e1f5">Passage into Mordor</card>
+    <card qty="1" id="7ce50ea4-2496-414f-8fd5-5b076b58c9ee">An Evil Place</card>
+  </section>
+  <section name="Second Quest Deck" shared="True" />
+  <section name="Encounter" shared="True">
+    <card qty="1" id="84b7e934-3d4d-4966-accf-c257c4413035">The Tunnels of Torech Gorgor</card>
+    <card qty="1" id="ede538df-8c8e-44b6-bab2-3a60e8a50449">A Haunt for Beasts</card>
+    <card qty="1" id="e0841275-753f-47bd-8d6d-807e4fb747ac">Overwhelming Darkness</card>
+    <card qty="2" id="c88d317b-d8b9-43ef-b41d-427ae4337f8d">Nameless Beast</card>
+    <card qty="2" id="ff815834-bf79-4914-8057-903f834190f1">Mordor Cave Troll</card>
+    <card qty="2" id="451b7209-4dea-4167-948e-dca0079fb997">Ash Mountain Werewolf</card>
+    <card qty="3" id="ba77505a-1def-4537-a194-0b7482433a72">Spawn of Shelob</card>
+    <card qty="1" id="df3f0718-7558-48c5-b680-2c2fc38d3de2">Torech Gorgor Patrol</card>
+    <card qty="3" id="ef7c6601-a62d-440a-89b1-5a9d6208481b">Fiery Chasm</card>
+    <card qty="2" id="b93c5b70-0655-4577-9f5e-68ca00d4bfc8">Hideous Deeps</card>
+    <card qty="2" id="fc8711c3-a458-4f0b-86d2-61fb3fd70316">Orc Passage</card>
+    <card qty="3" id="9832252b-4c87-4a03-b249-aa8abe404459">Ransacked Supplies</card>
+    <card qty="2" id="12a9c24d-c09d-4fd8-a746-4d75d30b7548">Burning Reek</card>
+    <card qty="2" id="b622efab-65dd-4a49-af87-8984066ab4ae">Writhing Shadows</card>
+    <card qty="2" id="67251171-ee5f-46d5-b3c8-10523350c60c">Twisted Tunnel</card>
+    <card qty="2" id="4b678143-ec9f-4727-998a-85dfef48d47a">Narrow Opening</card>
+    <card qty="2" id="6885658b-983d-459f-83f8-5a4d3ee5db9d">Crumbling Passage</card>
+    <card qty="2" id="64d1e3f3-3265-44a8-97f7-9a1c744a01b9">Fearful Shadows</card>
+    <card qty="1" id="c33f8472-2563-438e-94d3-77490d7c2175">Lost in the Dark</card>
+  </section>
+  <section name="Special" shared="True" />
+  <section name="Second Special" shared="True" />
+  <section name="Setup" shared="True" />
+  <section name="Staging Setup" shared="True">
+    <card qty="1" id="df3f0718-7558-48c5-b680-2c2fc38d3de2">Torech Gorgor Patrol</card>
+  </section>
+  <section name="Active Setup" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>


### PR DESCRIPTION
Due to a `git` mistake on my part, I forgot to add the Rhovanion `Easy/` folder and dropped a quest when I renamed it (Under the Ash Mountains). Sorry! 